### PR TITLE
Fix imagePullPolicy keys in nodeplugin template

### DIFF
--- a/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/cinder-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -37,7 +37,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -83,7 +82,6 @@ spec:
             initialDelaySeconds: {{ .Values.csi.livenessprobe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.csi.livenessprobe.timeoutSeconds }}
             periodSeconds: {{ .Values.csi.livenessprobe.periodSeconds }}
-          imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->
[cinder-csi-plugin] Fix imagePullPolicy keys in nodeplugin daemonset chart template

**What this PR does / why we need it**:
Fix imagePullPolicy keys in nodeplugin daemonset chart template

**Which issue this PR fixes(if applicable)**:
fixes #1598

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
